### PR TITLE
Celery Adjustments to implement propel2

### DIFF
--- a/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Propel\Generator\Behavior\CeleryDateTime;
+
+use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
+use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Util\PhpParser;
+
+/**
+ * Celery-specific behavior that overrides generated getters and setters for temporal columns.
+ *
+ * Key differences from default Propel temporal handling:
+ * - DATE columns skip timezone conversion entirely (dates are timezone-agnostic).
+ * - DATETIME/TIMESTAMP columns are stored and interpreted in America/Curacao timezone.
+ * - Getters support a 'carbon' format string to return a Carbon instance.
+ * - Getters reject strftime-style '%' formats (only PHP date() formats allowed).
+ * - '0000-00-00' values are treated as null.
+ */
+class CeleryDateTimeBehavior extends Behavior
+{
+    public function objectFilter(&$script)
+    {
+        $table = $this->getTable();
+        foreach ($table->getColumns() as $column) {
+            if (!$this->isTemporal($column)) {
+                continue;
+            }
+            $phpName = $column->getPhpName();
+            $newContent = $this->getNewGetterContent($column);
+            $parser = new PhpParser($script, true);
+            $parser->replaceMethod("get{$phpName}", $newContent);
+            $script = $parser->getCode();
+
+            $newContent = $this->getNewSetterContent($column);
+            $parser = new PhpParser($script, true);
+            $parser->replaceMethod("set{$phpName}", $newContent);
+            $script = $parser->getCode();
+        }
+    }
+
+    public function getNewGetterContent(Column $column)
+    {
+        $columnName = $column->getName();
+        $phpName = $column->getPhpName();
+        $isDate = $column->getType() === PropelTypes::DATE;
+
+        if ($isDate) {
+            $comment = "Custom Date getter for {$columnName} (no timezone conversion)";
+            $timezoneCode = '';
+            $errorMsg = 'date';
+        } else {
+            $comment = "Custom DateTime getter for {$columnName}";
+            $timezoneCode = "\n            \$dt->setTimeZone(new \\DateTimeZone(date_default_timezone_get()));";
+            $errorMsg = 'datetime';
+        }
+
+        return <<<PHP
+
+    /**
+     * {$comment}
+     */
+    public function get{$phpName}(?string \$format = 'Y-m-d')
+    {
+        if (\$this->{$columnName} === null) {
+            return null;
+        }
+
+        if (\$this->{$columnName} === '0000-00-00') {
+            return null;
+        }
+
+        try {
+            \$dt = clone \$this->{$columnName};{$timezoneCode}
+        } catch (\Exception \$x) {
+            throw new \Propel\Runtime\Exception\PropelException("Could not convert internal {$errorMsg} value: " . var_export(\$this->{$columnName}, true), 0, \$x);
+        }
+
+        if (\$format === null) {
+            return \$dt;
+        }
+
+        if (\$format === 'carbon') {
+            try {
+                return new \Carbon\Carbon(\$dt);
+            } catch (\Exception \$x) {
+                throw new \Propel\Runtime\Exception\PropelException("Carbon conversion failed.");
+            }
+        }
+
+        if (strpos(\$format, '%') !== false) {
+            throw new \Propel\Runtime\Exception\PropelException("strftime format is not supported. Use a date() format.");
+        }
+
+        return \$dt->format(\$format);
+    }
+
+PHP;
+    }
+
+    /**
+     * Determines if the given column is of a temporal type.
+     *
+     * This method checks the type of the specified column to determine if it is one of the
+     * temporal data types: DATE, DATETIME, TIME, or TIMESTAMP.
+     *
+     * @param \Propel\Generator\Model\Column $column The column to check.
+     * @return bool True if the column is temporal, false otherwise.
+     */
+    protected function isTemporal(\Propel\Generator\Model\Column $column): bool
+    {
+        $type = $column->getType();
+
+        return (
+            $type === PropelTypes::DATE
+            || $type === PropelTypes::DATETIME
+            || $type === PropelTypes::TIME
+            || $type === PropelTypes::TIMESTAMP
+        );
+    }
+
+    public function getNewSetterContent(Column $column)
+    {
+        $clo = $column->getLowercasedName();
+        $orNull = $column->isNotNull() ? '' : '|null';
+        $columnName = $column->getName();
+        $phpName = $column->getPhpName();
+        $format = $this->getFormat($column);
+        $isDate = $column->getType() === PropelTypes::DATE;
+
+        if ($isDate) {
+            $comment = "Sets the value of [$clo] column to a normalized version of the date value specified (no timezone conversion).";
+            $dateTimeConversion = <<<'PHP'
+        if ($v instanceof \DateTimeInterface) {
+            $v = $v->format('Y-m-d');
+        }
+
+PHP;
+            $timezoneArg = 'null';
+        } else {
+            $comment = "Sets the value of [$clo] column to a normalized version of the date/time value specified.";
+            $dateTimeConversion = '';
+            $timezoneArg = "new \\DateTimeZone('America/Curacao')";
+        }
+
+        return <<<PHP
+
+
+    /**
+     * {$comment}
+     * {$column->getDescription()}
+     * @param string|integer|\DateTimeInterface{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
+     *               Empty strings are treated as NULL.
+     * @return \$this The current object (for fluent API support)
+     */
+    public function set{$phpName}(\$v)
+    {
+        {$dateTimeConversion}\$dt = PropelDateTime::newInstance(\$v, {$timezoneArg}, 'DateTime');
+        if (\$this->{$columnName} !== null || \$dt !== null) {
+            if (\$this->{$columnName} === null || \$dt === null || \$dt->format("{$format}") !== \$this->{$columnName}->format("{$format}")) {
+                \$this->{$columnName} = \$dt === null ? null : clone \$dt;
+                \$this->modifiedColumns[{$column->getFQConstantName()}] = true;
+            }
+        } // if either are not null
+
+        return \$this;
+    }
+PHP;
+    }
+
+    protected function getFormat(Column $column): string
+    {
+        switch ($column->getType()) {
+            case 'DATE':
+                $format = 'Y-m-d';
+
+                break;
+            case 'TIME':
+                $format = 'H:i:s.u';
+
+                break;
+            default:
+                $format = 'Y-m-d H:i:s.u';
+        }
+
+        return $format;
+    }
+}

--- a/src/Propel/Generator/Behavior/CeleryEnum/CeleryEnumBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryEnum/CeleryEnumBehavior.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Propel\Generator\Behavior\CeleryEnum;
+
+use Propel\Generator\Model\Behavior;
+use Propel\Generator\Util\PhpParser;
+
+/**
+ * Celery-specific behavior that replaces the generated TableMap::getValueSets() method.
+ *
+ * By default, Propel maps ENUM values to integer indices (0, 1, 2, ...) in the value set array.
+ * This behavior changes the mapping so that ENUM value set arrays are keyed by their
+ * corresponding constant names (e.g. self::COL_STATUS_ACTIVE => self::COL_STATUS_ACTIVE),
+ * allowing string-based ENUM storage and lookup instead of positional integers.
+ */
+class CeleryEnumBehavior extends Behavior
+{
+    public function tableMapFilter(&$script)
+    {
+        $newContent = $this->getNewSetterContent();
+
+        $parser = new PhpParser($script, true);
+        $parser->replaceMethod("getValueSets", $newContent);
+
+        $script = $parser->getCode();
+    }
+
+    protected function getNewSetterContent(): string
+    {
+        $strReturn = <<<PHP
+
+
+    /**
+     * Gets the list of values for all ENUM and SET columns
+     * @return array
+     */
+    public static function getValueSets(): array
+    {
+
+PHP;
+        $strReturn .= "        return [";
+        foreach ($this->getTable()->getColumns() as $col) {
+            if ($col->isValueSetType()) {
+                $strReturn .= "
+            {$col->getFQConstantName()} => [
+";
+                foreach ($col->getValueSet() as $value) {
+                    $strConst = 'self::' . $col->getConstantName() . '_' . $this->getValueSetConstant($value);
+                    $strReturn .= "                {$strConst} => {$strConst},
+";
+                }
+                $strReturn .= '            ],';
+            }
+        }
+        $strReturn .= "
+        ];
+    }";
+
+        return $strReturn;
+    }
+
+    protected function getValueSetConstant(string $value): string
+    {
+        return strtoupper(preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '_', $value));
+    }
+}

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
@@ -66,6 +66,9 @@ class ConcreteInheritanceBehavior extends Behavior
         }
 
         // Add the columns of the parent table
+        // Celery: Collect PK columns during the loop so we can build a single foreign key
+        // that references all parts of a composite primary key (see below).
+        $newPrimaryKeyColumnsStore = [];
         foreach ($parentTable->getColumns() as $column) {
             if ($column->getName() == $this->getParameter('descendant_column')) {
                 continue;
@@ -79,15 +82,33 @@ class ConcreteInheritanceBehavior extends Behavior
             }
             $table->addColumn($copiedColumn);
             if ($column->isPrimaryKey() && $this->isCopyData()) {
+                //*** Store the new column for the primary key duplication logic.
+                $newPrimaryKeyColumnsStore[$column->getName()] = $copiedColumn;
+            }
+        }
+
+        if ($this->isCopyData()) {
+            // Celery: Replaced the original per-column FK creation with a single FK that
+            // iterates over all primary key columns. The original code created the FK inside
+            // the column loop, which only worked for single-column PKs. This version supports
+            // composite primary keys by collecting all PK columns first, then building one FK
+            // with a reference for each part.
+            $primaryKey = $parentTable->getPrimaryKey();
+            if (is_array($primaryKey) && count($primaryKey) > 0) {
                 $fk = new ForeignKey();
-                $fk->setForeignTableCommonName($column->getTable()->getCommonName());
-                if ($table->guessSchemaName() != $column->getTable()->guessSchemaName()) {
-                    $fk->setForeignSchemaName($column->getTable()->guessSchemaName());
-                }
+                $fk->setForeignTableCommonName($parentTable->getCommonName());
+                $fk->setForeignSchemaName($parentTable->getSchema());
                 $fk->setOnDelete('CASCADE');
                 $fk->setOnUpdate(null);
-                $fk->addReference($copiedColumn, $column);
                 $fk->isParentChild = true;
+
+                //*** Add a reference for each part of the priumary key, this adds support for composite keys.
+                foreach ($primaryKey as $column) {
+                    if (isset($newPrimaryKeyColumnsStore[$column->getName()])) {
+                        $fk->addReference($newPrimaryKeyColumnsStore[$column->getName()], $column);
+                    }
+                }
+
                 $table->addForeignKey($fk);
             }
         }

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -57,15 +57,20 @@ class TimestampableBehavior extends Behavior
         $table = $this->getTable();
 
         if ($this->withCreatedAt() && !$table->hasColumn($this->getParameter('create_column'))) {
+            // Celery: Changed from TIMESTAMP to DATETIME. TIMESTAMP columns in MySQL have
+            // automatic timezone conversion and a limited range (up to 2038), while DATETIME
+            // stores the literal value without conversion, which is what we need for explicit
+            // timezone handling via CeleryDateTimeBehavior.
             $table->addColumn([
                 'name' => $this->getParameter('create_column'),
-                'type' => 'TIMESTAMP',
+                'type' => 'DATETIME',
             ]);
         }
         if ($this->withUpdatedAt() && !$table->hasColumn($this->getParameter('update_column'))) {
+            // Celery: Changed from TIMESTAMP to DATETIME (see comment above).
             $table->addColumn([
                 'name' => $this->getParameter('update_column'),
-                'type' => 'TIMESTAMP',
+                'type' => 'DATETIME',
             ]);
         }
     }

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -234,7 +234,7 @@ class PropelTypes
     /**
      * @var string
      */
-    public const BIGINT_NATIVE_TYPE = 'string';
+    public const BIGINT_NATIVE_TYPE = 'int';
 
     /**
      * @var string

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -234,6 +234,9 @@ class PropelTypes
     /**
      * @var string
      */
+    // Celery: Changed from 'string' to 'int'. Propel defaults to string for BIGINT to avoid
+    // overflow on 32-bit systems, but our environment is 64-bit only, so native int is safe
+    // and avoids unnecessary string-to-int conversions throughout the application.
     public const BIGINT_NATIVE_TYPE = 'int';
 
     /**
@@ -475,7 +478,10 @@ class PropelTypes
         self::BOOLEAN_EMU => PDO::PARAM_INT,
         self::OBJECT => PDO::PARAM_LOB,
         self::PHP_ARRAY => PDO::PARAM_STR,
-        self::ENUM => PDO::PARAM_INT,
+        // Celery: Changed from PDO::PARAM_INT to PDO::PARAM_STR. Propel's default ENUM handling
+        // stores the positional index (int) of the value. With CeleryEnumBehavior, ENUMs are
+        // stored as their actual string values, so the PDO binding must use PARAM_STR.
+        self::ENUM => PDO::PARAM_STR,
         self::SET => PDO::PARAM_INT,
         self::GEOMETRY => PDO::PARAM_LOB,
 

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2253,7 +2253,10 @@ class Criteria
         }
 
         if ($stringToTransform) {
-            $parsedString .= preg_replace_callback("/[\w\\\]+\.\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
+            // Celery: Changed regex from "/[\w\\\]+\.\w+/" to "/[\w\\\+\.]+\w+/" to support
+            // schema-qualified column references (e.g. "schema.table.column") in expressions.
+            // The original pattern only matched a single dot between word characters.
+            $parsedString .= preg_replace_callback("/[\w\\\+\.]+\w+/", [$this, 'doReplaceNameInExpression'], $stringToTransform);
         }
 
         $sql = $parsedString;

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -2260,8 +2260,12 @@ class ModelCriteria extends BaseModelCriteria
         if (strpos($columnName, '.') === false) {
             $prefix = (string)$this->getModelAliasOrName();
         } else {
-            // $prefix could be either class name or table name
-            [$prefix, $columnName] = explode('.', $columnName);
+            // Celery: Replaced the original two-part explode (which assumed "prefix.column") with
+            // array_pop logic to support schema-qualified names like "schema.table.column".
+            // The column name is always the last segment; everything before it is the prefix.
+            $arrName = explode('.', $columnName);
+            $columnName = array_pop($arrName);
+            $prefix = implode(".", $arrName);
         }
 
         $shortClass = static::getShortName($prefix);

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use DateTimeZone;
 use PDO;
 use PDOException;
 use Propel\Generator\Model\PropelTypes;
@@ -326,7 +327,9 @@ abstract class PdoAdapter
     public function formatTemporalValue($value, ColumnMap $cMap): string
     {
         /** @var \Propel\Runtime\Util\PropelDateTime|null $dt */
-        $dt = PropelDateTime::newInstance($value);
+        // Celery: Hardcode America/Curacao timezone so temporal values in query bindings are
+        // interpreted consistently, matching the timezone used in PropelDateTime::newInstance().
+        $dt = PropelDateTime::newInstance($value, new DateTimeZone('America/Curacao'));
         if ($dt) {
             switch ($cMap->getType()) {
                 case PropelTypes::TIMESTAMP:

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -132,7 +132,11 @@ class PropelDateTime extends DateTime
     public static function newInstance($value, ?DateTimeZone $timeZone = null, string $dateTimeClass = 'DateTime')
     {
         if ($value instanceof DateTimeInterface) {
-            return $value;
+            // Celery: Clone and normalize to America/Curacao instead of returning the original
+            // object. This ensures all DateTimeInterface values entering the ORM are converted
+            // to the application's canonical timezone before storage.
+            $objDateTime = clone $value;
+            return $objDateTime->setTimezone(new \DateTimeZone("America/Curacao"));
         }
         if ($value === false || $value === null || $value === '') {
             // '' is seen as NULL for temporal objects
@@ -169,14 +173,17 @@ class PropelDateTime extends DateTime
                 $format = 'U.u';
             }
 
-            $dateTimeObject = DateTime::createFromFormat($format, $value, new DateTimeZone('UTC'));
+            // Celery: Changed from UTC to America/Curacao for both createFromFormat and
+            // setTimeZone. Timestamps are interpreted and stored in the application's
+            // canonical timezone rather than UTC.
+            $dateTimeObject = DateTime::createFromFormat($format, $value, new DateTimeZone('America/Curacao'));
             if ($dateTimeObject === false) {
                 throw new Exception(sprintf('Cannot create DateTime from format `%s`', $format));
             }
 
             // timezone must be explicitly specified and then changed
             // because of a DateTime bug: http://bugs.php.net/bug.php?id=43003
-            $dateTimeObject->setTimeZone(new DateTimeZone(date_default_timezone_get()));
+            $dateTimeObject->setTimeZone(new DateTimeZone('America/Curacao'));
         } else {
             if ($timeZone === null) {
                 // stupid DateTime constructor signature


### PR DESCRIPTION
Summary

- Add CeleryDateTimeBehavior and CeleryEnumBehavior to replicate custom Propel1 temporal and enum handling
- Hardcode America/Curacao as the canonical timezone for all temporal values across the ORM
- Fix schema-qualified column references, composite primary key inheritance, and type mappings

Motivation and Context

Closes #1

Celery has been running a customized Propel1 fork with adjustments for timezone handling, enum storage, type mappings, and schema-qualified table names. These changes port all those customizations to Propel2 as proper behaviors and targeted modifications, ensuring generated models and runtime behavior remain compatible with the existing database.

Changes

- CeleryDateTimeBehavior: Overrides temporal getters/setters — DATE columns skip timezone conversion, DATETIME/TIMESTAMP use America/Curacao, adds Carbon support, rejects strftime formats, treats 0000-00-00 as null
- CeleryEnumBehavior: Replaces integer-indexed ENUM value sets with string-keyed arrays, matching Celery's string-based ENUM storage
- ConcreteInheritanceBehavior: Builds a single FK referencing all parts of a composite primary key instead of creating one FK per PK column
- TimestampableBehavior: Uses DATETIME instead of TIMESTAMP for created_at/updated_at columns to avoid MySQL's automatic timezone conversion
- PropelTypes: BIGINT maps to int (64-bit environments only); ENUM uses PDO::PARAM_STR
- Criteria / ModelCriteria: Support schema-qualified column references (schema.table.column)
- PdoAdapter / PropelDateTime: Hardcode America/Curacao timezone for consistent temporal value interpretation

How Has This Been Tested

- Existing Propel2 test suite
- Manual verification against Celery's existing database schema and model generation

Types of Changes

- New feature (behaviors)
- Refactor (type mappings, timezone handling, query parsing)