### PR TITLE
Anchor DateTime getters to America/Curacao before local conversion

### DIFF
--- a/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
@@ -50,19 +50,19 @@ class CeleryDateTimeBehavior extends Behavior
 
         if ($isDate) {
             $comment = "Custom Date getter for {$columnName} (no timezone conversion)";
-            $timezoneCode = '';
+            $timezoneConversion = "\$dt = clone \$this->{$columnName};";
             $columnNullValue = "'0000-00-00'";
             $defaultFormat = "'Y-m-d'";
             $errorMsg = 'date';
         } elseif ($isTime) {
             $comment = "Custom Time getter for {$columnName} (no timezone conversion)";
-            $timezoneCode = '';
+            $timezoneConversion = "\$dt = clone \$this->{$columnName};";
             $columnNullValue = "null";
             $defaultFormat = "'H:i:s'";
             $errorMsg = 'time';
         } else {
             $comment = "Custom DateTime getter for {$columnName}";
-            $timezoneCode = "\n            \$dt->setTimeZone(new \\DateTimeZone(date_default_timezone_get()));";
+            $timezoneConversion = "\$dt = new \DateTime((\$this->{$columnName}->format('Y-m-d H:i:s')), new \DateTimeZone('America/Curacao'));\n            \$dt->setTimeZone(new \\DateTimeZone(date_default_timezone_get()));";
             $columnNullValue = "'0000-00-00 00:00:00'";
             $defaultFormat = "'Y-m-d H:i:s'";
             $errorMsg = 'datetime';
@@ -85,7 +85,7 @@ class CeleryDateTimeBehavior extends Behavior
         }
 
         try {
-            \$dt = clone \$this->{$columnName};{$timezoneCode}
+            {$timezoneConversion}
         } catch (\Exception \$x) {
             throw new \Propel\Runtime\Exception\PropelException("Could not convert internal {$errorMsg} value: " . var_export(\$this->{$columnName}, true), 0, \$x);
         }

--- a/tests/Propel/Tests/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehaviorTest.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Behavior\CeleryDateTime;
+
+use Propel\Generator\Behavior\CeleryDateTime\CeleryDateTimeBehavior;
+use Propel\Generator\Model\Column;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCase;
+
+/**
+ * Tests for CeleryDateTimeBehavior.
+ *
+ * @group model
+ */
+class CeleryDateTimeBehaviorTest extends TestCase
+{
+    /**
+     * Build the generated classes once per test class. The behavior overrides the
+     * temporal getters/setters on a DATETIME, a DATE and a TIME column so each
+     * branch can be exercised independently.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (class_exists('\CeleryTz\Event')) {
+            return;
+        }
+
+        $schema = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<database name="celery_tz" defaultIdMethod="native" namespace="CeleryTz">
+    <table name="event">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="occurred_at" type="TIMESTAMP"/>
+        <column name="event_date" type="DATE"/>
+        <column name="event_time" type="TIME"/>
+        <behavior name="celery_date_time"/>
+    </table>
+</database>
+XML;
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->buildClasses(null, true);
+    }
+
+    /**
+     * Reproduces the exact state after DB hydration: PDO loads the stored Curacao
+     * wall-clock string into a DateTime tagged with the PHP runtime default
+     * timezone. Assigning the property directly bypasses the setter (which would
+     * otherwise normalize the value via PropelDateTime::newInstance).
+     *
+     * @return void
+     */
+    public function testDateTimeGetterConvertsHydratedCuracaoValueToLocalTimezone()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $event = new \CeleryTz\Event();
+            $hydrated = new \DateTime('2026-04-27 12:00:00', new \DateTimeZone('UTC'));
+            $reflection = new \ReflectionProperty($event, 'occurred_at');
+            $reflection->setAccessible(true);
+            $reflection->setValue($event, $hydrated);
+
+            $result = $event->getOccurredAt(null);
+
+            // Curacao is UTC-4. A wall-clock of 12:00 stored in the DB represents
+            // 12:00 Curacao = 16:00 UTC. With local TZ = UTC, the getter must
+            // return a DateTime whose UTC wall-clock is 16:00.
+            $this->assertSame(
+                '2026-04-27 16:00:00',
+                $result->format('Y-m-d H:i:s'),
+                'DATETIME getter must anchor the stored wall-clock to America/Curacao before converting to the local timezone'
+            );
+            $this->assertSame('UTC', $result->getTimezone()->getName());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateTimeGetterIsIdempotentWhenLocalTimezoneIsCuracao()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('America/Curacao');
+
+            $event = new \CeleryTz\Event();
+            $hydrated = new \DateTime('2026-04-27 12:00:00', new \DateTimeZone('America/Curacao'));
+            $reflection = new \ReflectionProperty($event, 'occurred_at');
+            $reflection->setAccessible(true);
+            $reflection->setValue($event, $hydrated);
+
+            $result = $event->getOccurredAt(null);
+
+            $this->assertSame('2026-04-27 12:00:00', $result->format('Y-m-d H:i:s'));
+            $this->assertSame('America/Curacao', $result->getTimezone()->getName());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateGetterDoesNotConvertTimezone()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $event = new \CeleryTz\Event();
+            $hydrated = new \DateTime('2026-04-27', new \DateTimeZone('UTC'));
+            $reflection = new \ReflectionProperty($event, 'event_date');
+            $reflection->setAccessible(true);
+            $reflection->setValue($event, $hydrated);
+
+            $this->assertSame('2026-04-27', $event->getEventDate());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testTimeGetterDoesNotConvertTimezone()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $event = new \CeleryTz\Event();
+            $hydrated = new \DateTime('1970-01-01 09:30:00', new \DateTimeZone('UTC'));
+            $reflection = new \ReflectionProperty($event, 'event_time');
+            $reflection->setAccessible(true);
+            $reflection->setValue($event, $hydrated);
+
+            $this->assertSame('09:30:00', $event->getEventTime());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * Locks in the generator-level fix so a future refactor cannot silently
+     * regress to `clone $this->column; setTimeZone(local)` — a no-op when the
+     * underlying DateTime already carries the runtime default timezone.
+     *
+     * @return void
+     */
+    public function testGeneratedDateTimeGetterAnchorsValueToCuracaoBeforeLocalConversion()
+    {
+        $column = new Column('occurred_at', 'TIMESTAMP');
+        $behavior = new CeleryDateTimeBehavior();
+
+        $generated = $behavior->getNewGetterContent($column);
+
+        $this->assertStringContainsString(
+            "new \\DateTime((\$this->occurred_at->format('Y-m-d H:i:s')), new \\DateTimeZone('America/Curacao'))",
+            $generated,
+            'DATETIME getter must reconstruct the value with an explicit America/Curacao anchor'
+        );
+        $this->assertStringContainsString(
+            '$dt->setTimeZone(new \\DateTimeZone(date_default_timezone_get()))',
+            $generated,
+            'DATETIME getter must convert from Curacao to the local timezone'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fix `CeleryDateTimeBehavior` so generated DATETIME/TIMESTAMP getters correctly convert stored values from `America/Curacao` (the canonical storage timezone) to the application's local timezone.

The previous implementation cloned the hydrated `DateTime` (already in the runtime default timezone) and called `setTimeZone(...)`, which was a no-op — no Curacao→local conversion ever occurred. The fix reconstructs the `DateTime` explicitly anchored to `America/Curacao`, then converts to the local timezone.

DATE and TIME getters are timezone-agnostic by design and remain unaffected; this change refactors their generated code to use the same `$timezoneConversion` variable for consistency, but functionally they still skip timezone handling.

## Motivation and Context

closes #5

When the application runs in any timezone other than `America/Curacao`, retrieved DATETIME/TIMESTAMP values were wrong by the offset between the two zones. Any consumer reading a DATETIME or TIMESTAMP column through a generated getter saw the stored Curacao wall-clock time reinterpreted as local time.

## How Has This Been Tested

- Inspected the generated getter output for DATETIME, DATE, and TIME columns.
- Verified that values persisted via the setter (Curacao TZ) round-trip back through the getter as the same instant in the local TZ.
- Confirmed DATE and TIME getters still skip timezone handling.

Downstream consumers must regenerate their Propel models after merge to pick up the corrected getter code.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.