### PR TITLE
Anchor DateTime setter values to local timezone before Curacao conversion

### DIFF
--- a/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
@@ -164,12 +164,12 @@ PHP;
             $timezoneArg = 'null';
         } else {
             $comment = "Sets the value of [$clo] column to a normalized version of the date/time value specified.";
+            // Anchor naive strings to the runtime timezone so the Curacao conversion below shifts the wall-clock
+            // from the runtime timezone to America/Curacao. Without this wrap, strings would be treated as
+            // already-Curacao time. Numeric Unix timestamps bypass this branch inside PropelDateTime::newInstance()
+            // and anchor directly to Curacao — correct, since timestamps are timezone-agnostic.
             $dateTimeConversion = <<<'PHP'
-/**
-         * Convert a string or integer value to the local timezone for a correct conversion to database (Curacao) time.
-         * Clone any DateTimeInterface values to prevent internal manipulation of the original value.
-         */
-        if (!$v instanceof \DateTimeInterface) {
+if (!$v instanceof \DateTimeInterface) {
             $v = PropelDateTime::newInstance($v, new \DateTimeZone(date_default_timezone_get()), 'DateTime');
         }
 
@@ -186,8 +186,7 @@ PHP;
      * @param string|integer|\DateTimeInterface{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
      *               Empty strings are treated as NULL.
      * @return \$this The current object (for fluent API support)
-     * @throws PropelException
-     * @throws \DateInvalidTimeZoneException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function set{$phpName}(\$v)
     {

--- a/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
@@ -147,7 +147,7 @@ PHP;
         if ($isDate) {
             $comment = "Sets the value of [$clo] column to a normalized version of the date value specified (no timezone conversion).";
             $dateTimeConversion = <<<'PHP'
-        if ($v instanceof \DateTimeInterface) {
+if ($v instanceof \DateTimeInterface) {
             $v = $v->format('Y-m-d');
         }
 
@@ -156,7 +156,7 @@ PHP;
         } elseif ($isTime) {
             $comment = "Sets the value of [$clo] column to a normalized version of the time value specified (no timezone conversion).";
             $dateTimeConversion = <<<'PHP'
-        if ($v instanceof \DateTimeInterface) {
+if ($v instanceof \DateTimeInterface) {
             $v = $v->format('H:i:s.u');
         }
 
@@ -164,7 +164,16 @@ PHP;
             $timezoneArg = 'null';
         } else {
             $comment = "Sets the value of [$clo] column to a normalized version of the date/time value specified.";
-            $dateTimeConversion = '';
+            $dateTimeConversion = <<<'PHP'
+/**
+         * Convert a string or integer value to the local timezone for a correct conversion to database (Curacao) time.
+         * Clone any DateTimeInterface values to prevent internal manipulation of the original value.
+         */
+        if (!$v instanceof \DateTimeInterface) {
+            $v = PropelDateTime::newInstance($v, new \DateTimeZone(date_default_timezone_get()), 'DateTime');
+        }
+
+PHP;
             $timezoneArg = "new \\DateTimeZone('America/Curacao')";
         }
 
@@ -177,10 +186,13 @@ PHP;
      * @param string|integer|\DateTimeInterface{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
      *               Empty strings are treated as NULL.
      * @return \$this The current object (for fluent API support)
+     * @throws PropelException
+     * @throws \DateInvalidTimeZoneException
      */
     public function set{$phpName}(\$v)
     {
-        {$dateTimeConversion}\$dt = PropelDateTime::newInstance(\$v, {$timezoneArg}, 'DateTime');
+        {$dateTimeConversion}
+        \$dt = PropelDateTime::newInstance(\$v, {$timezoneArg}, 'DateTime');
         if (\$this->{$columnName} !== null || \$dt !== null) {
             if (\$this->{$columnName} === null || \$dt === null || \$dt->format("{$format}") !== \$this->{$columnName}->format("{$format}")) {
                 \$this->{$columnName} = \$dt === null ? null : clone \$dt;

--- a/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehavior.php
@@ -164,16 +164,20 @@ PHP;
             $timezoneArg = 'null';
         } else {
             $comment = "Sets the value of [$clo] column to a normalized version of the date/time value specified.";
-            // Anchor naive strings to the runtime timezone so the Curacao conversion below shifts the wall-clock
-            // from the runtime timezone to America/Curacao. Without this wrap, strings would be treated as
-            // already-Curacao time. Numeric Unix timestamps bypass this branch inside PropelDateTime::newInstance()
-            // and anchor directly to Curacao — correct, since timestamps are timezone-agnostic.
+
+            /**
+             * Anchor naive strings to the runtime timezone so the Curaçao conversion below shifts the wall-clock
+             * from the runtime timezone to America/Curacao. Without this wrap, strings would be treated as
+             * already-Curacao time. Numeric Unix timestamps bypass this branch inside PropelDateTime::newInstance()
+             * and anchor directly to Curaçao — correct, since timestamps are timezone-agnostic.
+             */
             $dateTimeConversion = <<<'PHP'
 if (!$v instanceof \DateTimeInterface) {
             $v = PropelDateTime::newInstance($v, new \DateTimeZone(date_default_timezone_get()), 'DateTime');
         }
 
 PHP;
+
             $timezoneArg = "new \\DateTimeZone('America/Curacao')";
         }
 
@@ -186,7 +190,6 @@ PHP;
      * @param string|integer|\DateTimeInterface{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
      *               Empty strings are treated as NULL.
      * @return \$this The current object (for fluent API support)
-     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function set{$phpName}(\$v)
     {

--- a/tests/Propel/Tests/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/CeleryDateTime/CeleryDateTimeBehaviorTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Generator\Behavior\CeleryDateTime;
 
 use Propel\Generator\Behavior\CeleryDateTime\CeleryDateTimeBehavior;
 use Propel\Generator\Model\Column;
+use Propel\Generator\Model\Database;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\TestCase;
 
@@ -176,5 +177,263 @@ XML;
             $generated,
             'DATETIME getter must convert from Curacao to the local timezone'
         );
+    }
+
+    /**
+     * Reproduces celery-payroll/web-app#4535: a naive string passed to a DATETIME
+     * setter under a non-Curacao runtime timezone must be interpreted in that
+     * runtime timezone first, then shifted to America/Curacao. Pre-fix, the
+     * string was handed straight to PropelDateTime::newInstance with the Curacao
+     * timezone and stored as-is — wrong by the local↔Curacao offset.
+     *
+     * @return void
+     */
+    public function testDateTimeSetterShiftsNaiveStringFromLocalTimezoneToCuracao()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $event = new \CeleryTz\Event();
+            $event->setOccurredAt('2026-04-28 10:00:00');
+
+            $stored = $this->readRawOccurredAt($event);
+
+            // 10:00 UTC → 06:00 America/Curacao (UTC-4, no DST).
+            $this->assertSame(
+                '2026-04-28 06:00:00',
+                $stored->format('Y-m-d H:i:s'),
+                'DATETIME setter must shift a naive string from the runtime timezone to America/Curacao'
+            );
+            $this->assertSame('America/Curacao', $stored->getTimezone()->getName());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateTimeSetterShiftsNaiveStringFromAmsterdamToCuracao()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('Europe/Amsterdam');
+
+            $event = new \CeleryTz\Event();
+            // Late April: Amsterdam is in CEST (UTC+2). 10:00 CEST = 04:00 Curacao.
+            $event->setOccurredAt('2026-04-28 10:00:00');
+
+            $stored = $this->readRawOccurredAt($event);
+
+            $this->assertSame(
+                '2026-04-28 04:00:00',
+                $stored->format('Y-m-d H:i:s'),
+                'DATETIME setter must honor the active runtime timezone, not assume Curacao'
+            );
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * A string with an embedded offset is unambiguous. The runtime-timezone wrap
+     * must NOT cause a second shift on top of the explicit offset.
+     *
+     * @return void
+     */
+    public function testDateTimeSetterRespectsExplicitOffsetWithoutDoubleShift()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $event = new \CeleryTz\Event();
+            // 10:00+02:00 = 08:00 UTC = 04:00 Curacao.
+            $event->setOccurredAt('2026-04-28 10:00:00+02:00');
+
+            $stored = $this->readRawOccurredAt($event);
+
+            $this->assertSame(
+                '2026-04-28 04:00:00',
+                $stored->format('Y-m-d H:i:s'),
+                'Embedded offset in the input string must not be double-shifted by the runtime-timezone wrap'
+            );
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * Integer Unix timestamps are timezone-agnostic. PropelDateTime::newInstance
+     * builds them directly in America/Curacao and ignores the supplied timezone,
+     * so the runtime timezone must not affect the stored Curacao wall-clock.
+     *
+     * @return void
+     */
+    public function testDateTimeSetterAnchorsUnixTimestampToCuracaoRegardlessOfRuntimeTimezone()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            // 1745834400 = 2025-04-28T10:00:00Z = 2025-04-28 06:00 Curacao.
+            $expected = '2025-04-28 06:00:00';
+
+            date_default_timezone_set('UTC');
+            $eventUtc = new \CeleryTz\Event();
+            $eventUtc->setOccurredAt(1745834400);
+
+            date_default_timezone_set('Asia/Tokyo');
+            $eventTokyo = new \CeleryTz\Event();
+            $eventTokyo->setOccurredAt(1745834400);
+
+            $this->assertSame($expected, $this->readRawOccurredAt($eventUtc)->format('Y-m-d H:i:s'));
+            $this->assertSame($expected, $this->readRawOccurredAt($eventTokyo)->format('Y-m-d H:i:s'));
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateTimeSetterStoresNullForEmptyStringAndNull()
+    {
+        $event = new \CeleryTz\Event();
+
+        $event->setOccurredAt('');
+        $this->assertNull($this->readRawOccurredAt($event), 'Empty string must persist as NULL');
+
+        $event->setOccurredAt(null);
+        $this->assertNull($this->readRawOccurredAt($event), 'null must persist as NULL');
+    }
+
+    /**
+     * The wrap is gated on `!$v instanceof \DateTimeInterface`, so DateTime and
+     * DateTimeImmutable inputs bypass it. They must still land in Curacao tz
+     * with the correct instant, and the caller's instance must not be mutated.
+     *
+     * @return void
+     */
+    public function testDateTimeSetterAcceptsDateTimeAndDateTimeImmutableWithoutMutation()
+    {
+        $originalTz = date_default_timezone_get();
+        try {
+            date_default_timezone_set('UTC');
+
+            $mutableInput = new \DateTime('2026-04-28 10:00:00', new \DateTimeZone('UTC'));
+            $immutableInput = new \DateTimeImmutable('2026-04-28 10:00:00', new \DateTimeZone('UTC'));
+
+            $eventA = new \CeleryTz\Event();
+            $eventA->setOccurredAt($mutableInput);
+
+            $eventB = new \CeleryTz\Event();
+            $eventB->setOccurredAt($immutableInput);
+
+            // 10:00 UTC = 06:00 Curacao for both inputs.
+            $this->assertSame('2026-04-28 06:00:00', $this->readRawOccurredAt($eventA)->format('Y-m-d H:i:s'));
+            $this->assertSame('2026-04-28 06:00:00', $this->readRawOccurredAt($eventB)->format('Y-m-d H:i:s'));
+
+            // Caller's mutable DateTime must not be mutated by the setter.
+            $this->assertSame('2026-04-28 10:00:00', $mutableInput->format('Y-m-d H:i:s'));
+            $this->assertSame('UTC', $mutableInput->getTimezone()->getName());
+        } finally {
+            date_default_timezone_set($originalTz);
+        }
+    }
+
+    /**
+     * The runtime-timezone wrap is meaningful only for DATETIME/TIMESTAMP. DATE
+     * and TIME columns are timezone-agnostic; if the wrap leaks into their
+     * generated setters, naive strings would be silently date-shifted across
+     * boundaries depending on the runtime timezone.
+     *
+     * @return void
+     */
+    public function testGeneratedDateAndTimeSettersDoNotWrapInputInRuntimeTimezone()
+    {
+        $behavior = new CeleryDateTimeBehavior();
+
+        $generatedDate = $behavior->getNewSetterContent($this->getColumnFromGeneratorSchema('event_date'));
+        $generatedTime = $behavior->getNewSetterContent($this->getColumnFromGeneratorSchema('event_time'));
+
+        $this->assertStringNotContainsString(
+            'date_default_timezone_get()',
+            $generatedDate,
+            'DATE setter must remain timezone-agnostic'
+        );
+        $this->assertStringNotContainsString(
+            'date_default_timezone_get()',
+            $generatedTime,
+            'TIME setter must remain timezone-agnostic'
+        );
+    }
+
+    /**
+     * Mirror of the existing getter-side regression lock: ensure the DATETIME
+     * setter explicitly anchors non-DateTimeInterface input to the runtime
+     * timezone before letting the surrounding code shift it to Curacao.
+     *
+     * @return void
+     */
+    public function testGeneratedDateTimeSetterAnchorsNonDateTimeInputToRuntimeTimezone()
+    {
+        $behavior = new CeleryDateTimeBehavior();
+
+        $generated = $behavior->getNewSetterContent($this->getColumnFromGeneratorSchema('occurred_at'));
+
+        $this->assertStringContainsString(
+            'if (!$v instanceof \DateTimeInterface)',
+            $generated,
+            'DATETIME setter must guard the wrap behind a DateTimeInterface check'
+        );
+        $this->assertStringContainsString(
+            "PropelDateTime::newInstance(\$v, new \\DateTimeZone(date_default_timezone_get()), 'DateTime')",
+            $generated,
+            'DATETIME setter must wrap non-DateTimeInterface input in the runtime timezone before the Curacao conversion'
+        );
+    }
+
+    /**
+     * @return \DateTimeInterface|null
+     */
+    private function readRawOccurredAt(\CeleryTz\Event $event)
+    {
+        $reflection = new \ReflectionProperty($event, 'occurred_at');
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($event);
+    }
+
+    /**
+     * Returns a Column attached to its parent table so generator helpers like
+     * Column::getFQConstantName() resolve correctly.
+     *
+     * @param string $columnName
+     * @return Column
+     */
+    private function getColumnFromGeneratorSchema(string $columnName): Column
+    {
+        static $database = null;
+
+        if ($database === null) {
+            $schema = <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<database name="celery_tz_gen" defaultIdMethod="native" namespace="CeleryTzGen">
+    <table name="event">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="occurred_at" type="TIMESTAMP"/>
+        <column name="event_date" type="DATE"/>
+        <column name="event_time" type="TIME"/>
+        <behavior name="celery_date_time"/>
+    </table>
+</database>
+XML;
+            $builder = new QuickBuilder();
+            $builder->setSchema($schema);
+            /** @var Database $database */
+            $database = $builder->getDatabase();
+        }
+
+        return $database->getTable('event')->getColumn($columnName);
     }
 }


### PR DESCRIPTION
## Summary

Generated DATETIME/TIMESTAMP setters now wrap non-`\DateTimeInterface` inputs (strings, integer Unix timestamps) into the active local timezone before letting the existing `America/Curacao` conversion shift them to database time. DATE and TIME branches are unchanged — the wrap lives only in the DATETIME branch.

## Motivation and Context

`CeleryDateTimeBehavior` previously passed naive strings and integers straight to `PropelDateTime::newInstance($v, new \DateTimeZone('America/Curacao'), 'DateTime')`, so a string like `"2026-04-28 10:00:00"` was treated as already-Curacao wall-clock time and never shifted from the active company timezone. When the active timezone differed from Curacao (e.g. `Europe/Amsterdam`), values were stored off by the local↔Curacao offset. This worked under Propel1 and regressed in commit `258e32ae83`. It surfaced downstream when extended Propel models hydrated parents via `populateFromArray()`-style paths and persisted the parent's datetime columns wrong.

This is the setter-side counterpart of #5 (which fixed the getter side).

closes #7
fixes celery-payroll/web-app#4535

## How Has This Been Tested

- Existing `CeleryDateTimeBehaviorTest` suite still passes locally.
- Behavior covered: strings without explicit TZ, strings with explicit offset, integer Unix timestamps, empty strings/`null`, `\DateTime`/`\DateTimeImmutable` instances, DATE columns, TIME columns.
- Downstream verification (proxy-class child→parent save, DST boundaries, `fromArray()` paths, CLI/worker contexts) will be performed in `web-app` after regenerating Base models against this behavior.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (docblock `@throws` annotations added).
- [x] I have added tests to cover my changes (existing behavior tests cover the affected setter paths).
- [x] All new and existing tests passed.