### PR TITLE
Preserve calendar date when binding DATE columns from non-Curacao timezones

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -326,12 +326,27 @@ abstract class PdoAdapter
      */
     public function formatTemporalValue($value, ColumnMap $cMap): string
     {
+        $columnType = $cMap->getType();
+
+        // Celery: DATE and TIME columns are timezone-agnostic per CeleryDateTimeBehavior.
+        // Format an existing DateTime in its source timezone — converting to America/Curacao
+        // here would shift the wall-clock across a day boundary for callers running in a
+        // timezone east of Curacao (e.g. Europe/Amsterdam), producing a date one day earlier.
+        if ($value instanceof \DateTimeInterface) {
+            if ($columnType === PropelTypes::DATE || $columnType === PropelTypes::BU_DATE) {
+                return $value->format($this->getDateFormatter());
+            }
+            if ($columnType === PropelTypes::TIME) {
+                return $value->format($this->getTimeFormatter());
+            }
+        }
+
         /** @var \Propel\Runtime\Util\PropelDateTime|null $dt */
         // Celery: Hardcode America/Curacao timezone so temporal values in query bindings are
         // interpreted consistently, matching the timezone used in PropelDateTime::newInstance().
         $dt = PropelDateTime::newInstance($value, new DateTimeZone('America/Curacao'));
         if ($dt) {
-            switch ($cMap->getType()) {
+            switch ($columnType) {
                 case PropelTypes::TIMESTAMP:
                 case PropelTypes::BU_TIMESTAMP:
                 case PropelTypes::DATETIME:

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/PdoAdapterFormatTemporalValueTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/PdoAdapterFormatTemporalValueTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Adapter\Pdo;
+
+use DateTime;
+use DateTimeZone;
+use Propel\Generator\Model\PropelTypes;
+use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
+use Propel\Runtime\Map\ColumnMap;
+use Propel\Runtime\Map\DatabaseMap;
+use Propel\Runtime\Map\TableMap;
+use Propel\Tests\TestCase;
+
+/**
+ * Regression coverage for PdoAdapter::formatTemporalValue() — the binding-time
+ * formatter used by every UPDATE/INSERT through Criteria.
+ *
+ * @group adapter
+ */
+class PdoAdapterFormatTemporalValueTest extends TestCase
+{
+    /**
+     * @var MysqlAdapter
+     */
+    private $adapter;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->adapter = new MysqlAdapter();
+    }
+
+    /**
+     * Reproduces the bug where saving a DATE column from a DateTime carrying a
+     * timezone east of America/Curacao writes the previous day to the DB. The
+     * original implementation funnelled every value through PropelDateTime::newInstance
+     * with America/Curacao, which shifted the wall-clock past midnight backwards.
+     *
+     * @return void
+     */
+    public function testDateColumnPreservesCalendarDateForDateTimeEastOfCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATE);
+        $value = new DateTime('1979-03-30 00:00:00', new DateTimeZone('Europe/Amsterdam'));
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateColumnPreservesCalendarDateForDateTimeFarEastOfCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATE);
+        $value = new DateTime('1979-03-30 00:00:00', new DateTimeZone('Asia/Tokyo'));
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateColumnPreservesCalendarDateForDateTimeWestOfCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATE);
+        $value = new DateTime('1979-03-30 00:00:00', new DateTimeZone('America/Los_Angeles'));
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateColumnPreservesCalendarDateForDateTimeInCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATE);
+        $value = new DateTime('1979-03-30 00:00:00', new DateTimeZone('America/Curacao'));
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * BU_DATE shares the DATE behavior — both must skip the Curacao normalization.
+     *
+     * @return void
+     */
+    public function testBuDateColumnPreservesCalendarDateForDateTimeEastOfCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::BU_DATE);
+        $value = new DateTime('1979-03-30 00:00:00', new DateTimeZone('Europe/Amsterdam'));
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * @return void
+     */
+    public function testTimeColumnPreservesWallClockForDateTimeInDifferentTimezone(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::TIME);
+        $value = new DateTime('1979-03-30 09:30:00', new DateTimeZone('Europe/Amsterdam'));
+
+        $this->assertSame('09:30:00.000000', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * Non-DateTime values still flow through PropelDateTime::newInstance with the
+     * Curacao timezone. A plain date string must round-trip unchanged.
+     *
+     * @return void
+     */
+    public function testDateColumnAcceptsRawDateString(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATE);
+
+        $this->assertSame('1979-03-30', $this->adapter->formatTemporalValue('1979-03-30', $cMap));
+    }
+
+    /**
+     * DATETIME columns must continue to normalize the wall-clock to America/Curacao.
+     * 10:00 in Europe/Amsterdam (CET, UTC+1) corresponds to 05:00 in Curacao (UTC-4).
+     *
+     * @return void
+     */
+    public function testDateTimeColumnNormalizesWallClockToCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::DATETIME);
+        $value = new DateTime('2025-01-15 10:00:00', new DateTimeZone('Europe/Amsterdam'));
+
+        $this->assertSame('2025-01-15 05:00:00.000000', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * TIMESTAMP shares DATETIME behavior — wall-clock must be anchored to Curacao.
+     *
+     * @return void
+     */
+    public function testTimestampColumnNormalizesWallClockToCuracao(): void
+    {
+        $cMap = $this->buildColumnMap(PropelTypes::TIMESTAMP);
+        $value = new DateTime('2025-01-15 10:00:00', new DateTimeZone('Europe/Amsterdam'));
+
+        $this->assertSame('2025-01-15 05:00:00.000000', $this->adapter->formatTemporalValue($value, $cMap));
+    }
+
+    /**
+     * @param string $type One of the PropelTypes::* temporal constants.
+     * @return ColumnMap
+     */
+    private function buildColumnMap(string $type): ColumnMap
+    {
+        $databaseMap = new DatabaseMap('test_db');
+        $tableMap = new TableMap('test_table', $databaseMap);
+
+        return new ColumnMap('value', $tableMap, 'Value', $type);
+    }
+}


### PR DESCRIPTION
## Summary

`PdoAdapter::formatTemporalValue` no longer pulls DATE/BU_DATE/TIME columns through `PropelDateTime::newInstance` with `America/Curacao`. For those types it now formats the source `DateTime` in its own timezone, matching the `CeleryDateTimeBehavior` contract that DATE and TIME columns are timezone-agnostic. DATETIME/TIMESTAMP normalization is unchanged.

## Motivation and Context

Saving a DATE column from a `DateTime` carrying a timezone east of Curacao (e.g. `Europe/Amsterdam`) wrote the previous calendar date to the database. The adapter cloned the value and called `setTimezone(America/Curacao)`, which moved `1979-03-30 00:00:00 Europe/Amsterdam` to `1979-03-29 19:00:00 America/Curacao`; `format('Y-m-d')` then bound `1979-03-29` to the SQL parameter.

The custom `setDateOfBirth`-style setter generated by `CeleryDateTimeBehavior` already captures the date in the source timezone first, but the stored `DateTime` still carries the runtime timezone, so the adapter's normalization on save undid the setter's care. DATETIME/TIMESTAMP columns weren't affected because their setter anchors the stored value to Curacao up front, making the adapter's second normalization a no-op.

closes #9

## How Has This Been Tested

New unit tests in `tests/Propel/Tests/Runtime/Adapter/Pdo/PdoAdapterFormatTemporalValueTest.php` cover:

- DATE bindings from `DateTime` in `Europe/Amsterdam`, `Asia/Tokyo`, `America/Los_Angeles`, and `America/Curacao` — all preserve the calendar date.
- BU_DATE binding from `DateTime` east of Curacao — same guarantee.
- TIME binding from `DateTime` in a non-Curacao timezone — preserves wall-clock.
- DATE binding from a raw date string — round-trips unchanged.
- DATETIME and TIMESTAMP bindings — wall-clock still anchored to Curacao (regression lock for the existing behavior).

Verified the suite catches the bug: reverting the adapter change makes 4 of the 9 tests fail (exactly the cases that crossed the day boundary). Existing `CeleryDateTimeBehaviorTest` still passes (13/13).

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.