### PR TITLE
Add celery_column_length behavior to validate text column lengths

### DIFF
--- a/src/Propel/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehavior.php
+++ b/src/Propel/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehavior.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Propel\Generator\Behavior\CeleryColumnLength;
+
+use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
+
+/**
+ * Celery-specific behavior that validates text column lengths before a row is written.
+ *
+ * An over-long value would otherwise reach MySQL and come back as a raw
+ * "SQLSTATE[22001] ... Data too long for column 'x'" error, which surfaces to the end user as
+ * an unreadable SQL string. This behavior checks the length first and raises a typed exception
+ * carrying the table, column, allowed length and actual length, so the application can render a
+ * localised message.
+ *
+ * Usage in schema.xml within a [table] node:
+ * <behavior name="celery_column_length"/>
+ *
+ * Optional parameters:
+ * <behavior name="celery_column_length">
+ *     <parameter name="validator" value="\Propel\Runtime\Util\ColumnLengthValidator"/>
+ *     <parameter name="exclude_columns" value="[column_name_to_skip],[another]"/>
+ * </behavior>
+ *
+ * The 'validator' parameter exists so a project can substitute its own checker; it defaults to
+ * the one shipped with the package, so the generated code never references a class the package
+ * does not provide.
+ *
+ * The behavior injects a single validator call into the generated doSave() via the preSave hook,
+ * so the generated code stays small regardless of how many text columns the table has. Only
+ * modified columns are checked at runtime: an unmodified value was loaded from the database and
+ * therefore already fits, and re-checking it would make existing rows unsaveable if a migration
+ * ever shrank a column.
+ */
+class CeleryColumnLengthBehavior extends Behavior
+{
+    //*** Default parameters value.
+    protected $parameters = [
+        "validator" => "\\Propel\\Runtime\\Util\\ColumnLengthValidator",
+        "exclude_columns" => null,
+    ];
+
+    /**
+     * Inject the length validation into the generated doSave() method, before the insert/update.
+     *
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     * @return string The PHP code to inject, or an empty string when the table has no sized text columns.
+     */
+    public function preSave($builder): string
+    {
+        $arrColumns = $this->getValidatableColumns();
+
+        if (count($arrColumns) === 0) {
+            return "";
+        }
+
+        $strTableMap = $builder->getClassNameFromBuilder($builder->getNewTableMapBuilder($this->getTable()));
+
+        //*** Emit a fully qualified name: the generated code lives in the model's own namespace,
+        //*** where a relative reference would resolve against that namespace instead of the root.
+        $strValidator = "\\" . ltrim((string)$this->getParameter("validator"), "\\");
+        $arrEntries = [];
+
+        foreach ($arrColumns as $objColumn) {
+            $arrEntries[] = sprintf(
+                "        [%s, '%s', '%s', %d, \$this->%s],",
+                $objColumn->getFQConstantName(),
+                $objColumn->getName(),
+                $objColumn->getPhpName(),
+                (int)$objColumn->getSize(),
+                $objColumn->getLowercasedName()
+            );
+        }
+
+        $strEntries = implode("\n", $arrEntries);
+
+        //*** Propel prefixes the injected block with a "// celery_column_length behavior" label itself.
+        return <<<PHP
+{$strValidator}::validate(
+    {$strTableMap}::TABLE_NAME,
+    \$this->modifiedColumns,
+    [
+{$strEntries}
+    ]
+);
+PHP;
+    }
+
+    /**
+     * Collect the text columns that carry a usable maximum length.
+     *
+     * LOB columns are skipped: their size in the schema does not describe a character limit.
+     * Columns listed in the 'exclude_columns' parameter are skipped as well.
+     *
+     * @return array<int, \Propel\Generator\Model\Column>
+     */
+    protected function getValidatableColumns(): array
+    {
+        $arrExcluded = $this->getExcludedColumnNames();
+        $arrReturn = [];
+
+        foreach ($this->getTable()->getColumns() as $objColumn) {
+            if (!$this->isValidatable($objColumn) || in_array($objColumn->getName(), $arrExcluded, true)) {
+                continue;
+            }
+
+            $arrReturn[] = $objColumn;
+        }
+
+        return $arrReturn;
+    }
+
+    /**
+     * Determine whether the given column is a sized, non-LOB text column.
+     *
+     * @param \Propel\Generator\Model\Column $objColumn The column to check.
+     * @return bool True when the column value should be length checked.
+     */
+    protected function isValidatable(Column $objColumn): bool
+    {
+        return $objColumn->isTextType()
+            && !$objColumn->isLobType()
+            && (int)$objColumn->getSize() > 0;
+    }
+
+    /**
+     * Read the 'exclude_columns' parameter as a list of column names.
+     *
+     * @return array<int, string>
+     */
+    protected function getExcludedColumnNames(): array
+    {
+        $strExcluded = (string)$this->getParameter("exclude_columns");
+
+        if (trim($strExcluded) === "") {
+            return [];
+        }
+
+        return array_values(array_filter(array_map("trim", explode(",", $strExcluded))));
+    }
+}

--- a/src/Propel/Runtime/Exception/ColumnValueTooLongException.php
+++ b/src/Propel/Runtime/Exception/ColumnValueTooLongException.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\Exception;
+
+use Exception;
+
+/**
+ * Thrown when a value is too long for the database column it would be written to.
+ *
+ * Raised by Propel\Runtime\Util\ColumnLengthValidator from the generated doSave() when the
+ * celery_column_length behavior is enabled, before the INSERT or UPDATE reaches the database.
+ * It replaces the driver's raw "SQLSTATE[22001] ... Data too long for column 'x'" error with a
+ * typed exception carrying everything a caller needs to build a readable message: the table, the
+ * column (database and PHP name), the allowed length and the actual one.
+ */
+class ColumnValueTooLongException extends PropelException
+{
+    /**
+     * @param string $tableName The database table being written to.
+     * @param string $columnName The database column name that received the over-long value.
+     * @param string $phpName The Propel PHP name of the column.
+     * @param int $maxLength The maximum number of characters the column accepts.
+     * @param int $actualLength The number of characters in the rejected value.
+     * @param \Throwable|null $previous The previous exception, if any.
+     */
+    public function __construct(
+        protected string $tableName,
+        protected string $columnName,
+        protected string $phpName,
+        protected int $maxLength,
+        protected int $actualLength,
+        ?\Throwable $previous = null
+    ) {
+        $message = sprintf(
+            "The value for '%s.%s' is too long: %d characters given, %d allowed.",
+            $tableName,
+            $columnName,
+            $actualLength,
+            $maxLength
+        );
+
+        Exception::__construct($message, 0, $previous);
+    }
+
+    /**
+     * Get the database table being written to.
+     *
+     * @return string
+     */
+    public function getTableName(): string
+    {
+        return $this->tableName;
+    }
+
+    /**
+     * Get the database column name that received the over-long value.
+     *
+     * @return string
+     */
+    public function getColumnName(): string
+    {
+        return $this->columnName;
+    }
+
+    /**
+     * Get the Propel PHP name of the column.
+     *
+     * @return string
+     */
+    public function getPhpName(): string
+    {
+        return $this->phpName;
+    }
+
+    /**
+     * Get the maximum number of characters the column accepts.
+     *
+     * @return int
+     */
+    public function getMaxLength(): int
+    {
+        return $this->maxLength;
+    }
+
+    /**
+     * Get the number of characters in the rejected value.
+     *
+     * @return int
+     */
+    public function getActualLength(): int
+    {
+        return $this->actualLength;
+    }
+}

--- a/src/Propel/Runtime/Util/ColumnLengthValidator.php
+++ b/src/Propel/Runtime/Util/ColumnLengthValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\Util;
+
+use Propel\Runtime\Exception\ColumnValueTooLongException;
+
+/**
+ * Validates text column lengths before a model is written to the database.
+ *
+ * Called from the generated doSave() by the celery_column_length behavior. Keeping the logic here
+ * rather than inlining it per column keeps the generated model code to a single call, whatever the
+ * number of text columns on the table.
+ */
+class ColumnLengthValidator
+{
+    /**
+     * Check every supplied column value against its maximum length.
+     *
+     * Only modified columns are checked. An unmodified value was loaded from the database and
+     * therefore already fits — re-checking it would make existing rows unsaveable after a
+     * migration shrank a column, even when the caller never touched that column.
+     *
+     * Length is measured in characters rather than bytes, because a VARCHAR size counts characters.
+     *
+     * @param string $tableName The database table being written to.
+     * @param array<string, bool> $modifiedColumns The model's modifiedColumns map, keyed by column constant.
+     * @param array<int, array{0: string, 1: string, 2: string, 3: int, 4: mixed}> $columns
+     *        One entry per column: [fully qualified column constant, database name, PHP name,
+     *        maximum length, current value].
+     *
+     * @throws \Propel\Runtime\Exception\ColumnValueTooLongException When a value exceeds its column length.
+     *
+     * @return void
+     */
+    public static function validate(string $tableName, array $modifiedColumns, array $columns): void
+    {
+        foreach ($columns as [$constant, $columnName, $phpName, $maxLength, $value]) {
+            if ($value === null || !isset($modifiedColumns[$constant])) {
+                continue;
+            }
+
+            $actualLength = mb_strlen((string)$value);
+
+            if ($actualLength <= $maxLength) {
+                continue;
+            }
+
+            throw new ColumnValueTooLongException($tableName, $columnName, $phpName, $maxLength, $actualLength);
+        }
+    }
+}

--- a/tests/Propel/Tests/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehaviorTest.php
@@ -1,0 +1,356 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Behavior\CeleryColumnLength;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Exception\ColumnValueTooLongException;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Util\ColumnLengthValidator;
+use Propel\Tests\TestCase;
+
+/**
+ * Tests for CeleryColumnLengthBehavior, ColumnLengthValidator and ColumnValueTooLongException.
+ *
+ * @group model
+ */
+class CeleryColumnLengthBehaviorTest extends TestCase
+{
+    /**
+     * Build the generated classes against an in-memory SQLite database so the injected
+     * validation can be exercised through the real save() path.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (class_exists('\CeleryLength\Item')) {
+            return;
+        }
+
+        $builder = new QuickBuilder();
+        $builder->setSchema(static::getRuntimeSchema());
+        $builder->build();
+    }
+
+    /**
+     * A table covering every branch: sized text columns, a LOB, an unsized text column,
+     * a non-text column and an excluded column.
+     *
+     * @return string
+     */
+    protected static function getRuntimeSchema(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<database name="celery_length" defaultIdMethod="native" namespace="CeleryLength">
+    <table name="item">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="code" type="VARCHAR" size="3"/>
+        <column name="label" type="VARCHAR" size="10"/>
+        <column name="skipped" type="VARCHAR" size="2"/>
+        <column name="payload" type="BLOB"/>
+        <column name="notes" type="LONGVARCHAR"/>
+        <column name="quantity" type="INTEGER"/>
+        <behavior name="celery_column_length">
+            <parameter name="exclude_columns" value="skipped"/>
+        </behavior>
+    </table>
+</database>
+XML;
+    }
+
+    /**
+     * Generated source for the schema above, without building or evaluating the classes.
+     *
+     * @return string
+     */
+    protected function getGeneratedSource(): string
+    {
+        static $source = null;
+
+        if ($source === null) {
+            $builder = new QuickBuilder();
+            $builder->setSchema(str_replace(
+                ['celery_length', 'CeleryLength'],
+                ['celery_length_gen', 'CeleryLengthGen'],
+                static::getRuntimeSchema()
+            ));
+            $source = $builder->getClasses();
+        }
+
+        return $source;
+    }
+
+    /**
+     * The argument list of the injected validator call.
+     *
+     * Assertions must be scoped to this block rather than the whole generated source: the
+     * TableMap separately emits `addColumn('skipped', 'Skipped', 'VARCHAR', ...)` for every
+     * column, so a negative assertion against the full source matches the TableMap and can
+     * never fail, whatever the behavior does.
+     *
+     * @param string|null $source
+     * @return string
+     */
+    protected function getInjectedValidatorBlock(?string $source = null): string
+    {
+        $source = $source ?? $this->getGeneratedSource();
+
+        if (!preg_match('/ColumnLengthValidator::validate\((.*?)\n\s*\);/s', $source, $matches)) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * @return void
+     */
+    public function testOverLongValueThrowsWithFullMetadata()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('EURO');
+
+        try {
+            $item->save();
+            $this->fail('Saving an over-long value must throw ColumnValueTooLongException');
+        } catch (ColumnValueTooLongException $e) {
+            $this->assertSame('item', $e->getTableName());
+            $this->assertSame('code', $e->getColumnName());
+            $this->assertSame('Code', $e->getPhpName());
+            $this->assertSame(3, $e->getMaxLength());
+            $this->assertSame(4, $e->getActualLength());
+            $this->assertSame(
+                "The value for 'item.code' is too long: 4 characters given, 3 allowed.",
+                $e->getMessage()
+            );
+        }
+    }
+
+    /**
+     * Existing application code catches PropelException around save(); the new exception
+     * must stay inside that hierarchy or those handlers would stop working.
+     *
+     * @return void
+     */
+    public function testExceptionIsCatchableAsPropelException()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('EURO');
+
+        $this->expectException(PropelException::class);
+
+        $item->save();
+    }
+
+    /**
+     * @return void
+     */
+    public function testValueAtExactlyTheLimitIsAccepted()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('EUR');
+        $item->setLabel('0123456789');
+
+        $item->save();
+
+        $this->assertNotNull($item->getId(), 'A value at exactly the column length must save');
+    }
+
+    /**
+     * A VARCHAR size counts characters, not bytes. 'éàü' is 6 bytes but 3 characters and
+     * must fit a VARCHAR(3); a byte-based check would wrongly reject it.
+     *
+     * @return void
+     */
+    public function testMultiByteValueIsMeasuredInCharactersNotBytes()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('éàü');
+
+        $item->save();
+
+        $this->assertNotNull($item->getId(), 'Three multi-byte characters must fit a VARCHAR(3)');
+    }
+
+    /**
+     * @return void
+     */
+    public function testMultiByteValueOverTheLimitStillThrowsWithCharacterCount()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('éàüö');
+
+        try {
+            $item->save();
+            $this->fail('Four multi-byte characters must not fit a VARCHAR(3)');
+        } catch (ColumnValueTooLongException $e) {
+            $this->assertSame(4, $e->getActualLength(), 'Length must be reported in characters');
+        }
+    }
+
+    /**
+     * An update must validate the column being written but leave untouched columns alone.
+     *
+     * @return void
+     */
+    public function testUpdateValidatesModifiedColumnOnly()
+    {
+        $item = new \CeleryLength\Item();
+        $item->setCode('EUR');
+        $item->save();
+
+        $item->setLabel('short');
+        $item->save();
+
+        $this->assertSame('short', $item->getLabel(), 'Updating an unrelated column must succeed');
+
+        $item->setLabel('far too long to fit');
+
+        $this->expectException(ColumnValueTooLongException::class);
+
+        $item->save();
+    }
+
+    /**
+     * The validator is driven by the modifiedColumns map, so a value that was never
+     * assigned must not be checked. This is what keeps rows saveable after a migration
+     * shrinks a column: the stale value is only rejected if the caller writes to it.
+     *
+     * @return void
+     */
+    public function testUnmodifiedColumnIsSkipped()
+    {
+        ColumnLengthValidator::validate('item', [], [
+            ['ITEM.CODE', 'code', 'Code', 3, 'EURO'],
+        ]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return void
+     */
+    public function testNullValueIsSkipped()
+    {
+        ColumnLengthValidator::validate('item', ['ITEM.CODE' => true], [
+            ['ITEM.CODE', 'code', 'Code', 3, null],
+        ]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return void
+     */
+    public function testValidatorReportsTheFirstOffendingColumn()
+    {
+        $this->expectException(ColumnValueTooLongException::class);
+        $this->expectExceptionMessage("The value for 'item.label' is too long: 19 characters given, 10 allowed.");
+
+        ColumnLengthValidator::validate('item', ['ITEM.CODE' => true, 'ITEM.LABEL' => true], [
+            ['ITEM.CODE', 'code', 'Code', 3, 'EUR'],
+            ['ITEM.LABEL', 'label', 'Label', 10, 'far too long to fit'],
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testGeneratedCodeChecksSizedTextColumns()
+    {
+        $block = $this->getInjectedValidatorBlock();
+
+        $this->assertNotSame('', $block, 'The behavior must inject a validator call');
+        $this->assertStringContainsString("'code', 'Code', 3", $block);
+        $this->assertStringContainsString("'label', 'Label', 10", $block);
+    }
+
+    /**
+     * The generated code lives in the model's own namespace, so a relative reference
+     * would resolve against that namespace instead of the root.
+     *
+     * @return void
+     */
+    public function testGeneratedCodeUsesFullyQualifiedValidatorName()
+    {
+        $this->assertStringContainsString(
+            '\Propel\Runtime\Util\ColumnLengthValidator::validate(',
+            $this->getGeneratedSource(),
+            'The emitted validator reference must be fully qualified'
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGeneratedCodePassesModifiedColumnsMap()
+    {
+        $this->assertStringContainsString('$this->modifiedColumns', $this->getInjectedValidatorBlock());
+    }
+
+    /**
+     * A BLOB size does not describe a character limit, an unsized text column has no
+     * limit to check, and a non-text column cannot overflow a length.
+     *
+     * @return void
+     */
+    public function testGeneratedCodeSkipsLobUnsizedAndNonTextColumns()
+    {
+        $block = $this->getInjectedValidatorBlock();
+
+        $this->assertNotSame('', $block, 'The behavior must inject a validator call');
+        $this->assertStringNotContainsString("'payload', 'Payload'", $block, 'LOB columns must not be checked');
+        $this->assertStringNotContainsString("'notes', 'Notes'", $block, 'Unsized text columns must not be checked');
+        $this->assertStringNotContainsString("'quantity', 'Quantity'", $block, 'Non-text columns must not be checked');
+    }
+
+    /**
+     * @return void
+     */
+    public function testGeneratedCodeHonoursExcludeColumns()
+    {
+        $block = $this->getInjectedValidatorBlock();
+
+        $this->assertNotSame('', $block, 'The behavior must inject a validator call');
+        $this->assertStringNotContainsString(
+            "'skipped', 'Skipped'",
+            $block,
+            'Columns listed in exclude_columns must not be checked'
+        );
+    }
+
+    /**
+     * A table whose only text columns are excluded, LOB or unsized must get no call at
+     * all, rather than an empty validate() invocation.
+     *
+     * @return void
+     */
+    public function testTableWithoutValidatableColumnsGetsNoCall()
+    {
+        $builder = new QuickBuilder();
+        $builder->setSchema(<<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<database name="celery_length_empty" defaultIdMethod="native" namespace="CeleryLengthEmpty">
+    <table name="plain">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="quantity" type="INTEGER"/>
+        <column name="notes" type="LONGVARCHAR"/>
+        <behavior name="celery_column_length"/>
+    </table>
+</database>
+XML);
+
+        $this->assertStringNotContainsString(
+            'ColumnLengthValidator::validate(',
+            $builder->getClasses(),
+            'A table with no validatable columns must not emit a validator call'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `celery_column_length` behavior that checks text column lengths before a row is written, so an over-long value raises a typed exception instead of a raw driver error.

Three new files:

- `Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehavior.php` — uses the `preSave` hook to inject a single validator call into the generated `doSave()`, listing each sized text column with its maximum length. Skips LOB, unsized and non-text columns. Parameters: `validator` (defaults to the in-package class) and `exclude_columns`.
- `Runtime/Util/ColumnLengthValidator.php` — static `validate(string $tableName, array $modifiedColumns, array $columns)`.
- `Runtime/Exception/ColumnValueTooLongException.php` — extends `PropelException`, exposes `getTableName()`, `getColumnName()`, `getPhpName()`, `getMaxLength()` and `getActualLength()`.

Usage in `schema.xml`:

```xml
<behavior name="celery_column_length"/>
```

Design decisions worth keeping in review:

- **Only modified columns are checked.** An unmodified value came from the database and already fits; re-checking it would make existing rows unsaveable if a migration ever shrank a column.
- **Length is measured with `mb_strlen`, not `strlen`.** A VARCHAR size counts characters, so `'éàü'` (6 bytes, 3 characters) must fit a `VARCHAR(3)`.
- **The validator ships with the package.** The `validator` parameter allows substitution but defaults to an in-package class, so a fresh install never generates code referencing a class that does not exist.
- **The emitted class name is fully qualified.** Generated models live in the project's own namespace, where a relative reference would resolve against that namespace instead of the root.
- **`preSave`, not the setters.** Validating in generated setters would break existing code that sets an over-long value and trims or discards it later.
- **One call per table, not one per column.** The generated code stays the same size regardless of how many text columns the table has.
- **`ColumnValueTooLongException` calls `Exception::__construct()` directly**, bypassing `PropelException::__construct()`. This is deliberate: `PropelException` prepends previous-exception detail to the message, which would corrupt the clean, renderable message this exception exists to provide. The class still extends `PropelException`, so existing `catch (PropelException)` handlers around `save()` keep working.

## Motivation and Context

closes #12

Writing an over-long value to a text column currently fails at the driver with `SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'x'`. Propel wraps that in `PropelException("Unable to execute INSERT statement [...]")`, so the only thing an application can do is show the raw SQL to the end user — see celery-payroll/web-app#3699 for the user-facing report.

Applications need a typed exception carrying the table, column, allowed length and actual length so they can render their own localised message.

## How Has This Been Tested

New test file `tests/Propel/Tests/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehaviorTest.php` — 15 tests, 28 assertions, all passing:

```
vendor/bin/phpunit tests/Propel/Tests/Generator/Behavior/CeleryColumnLength/CeleryColumnLengthBehaviorTest.php
OK (15 tests, 28 assertions)
```

It builds a fixture table via `QuickBuilder` against in-memory SQLite, so the injected validation is exercised through the real `save()` path, and separately asserts on the generated source.

Runtime behavior covered:

- over-long value throws with the correct table, column, PHP name, max length, actual length and message
- the exception is catchable as `PropelException`, so existing handlers around `save()` keep working
- a value at exactly the column length saves
- multi-byte characters count as characters, both under and over the limit
- an update validates the modified column and leaves untouched columns alone
- unmodified columns and `null` values are skipped
- the first offending column is the one reported

Code generation covered:

- sized text columns appear in the injected call with their lengths
- the emitted validator reference is fully qualified
- `$this->modifiedColumns` is passed through
- LOB, unsized text and non-text columns are not checked
- `exclude_columns` is honoured
- a table with no validatable columns emits no call at all, rather than an empty `validate()`

Negative assertions are scoped to the injected argument block rather than the whole generated source, because the TableMap emits `addColumn('skipped', 'Skipped', 'VARCHAR', ...)` for every column — a negative assertion against the full source would match the TableMap and could never fail.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] All new code lives in a new `Behavior/CeleryColumnLength` namespace — no upstream-owned file is modified, keeping the fork rebasable
- [x] The behavior is opt-in per schema; tables without it generate identical code to before
- [x] New public classes and methods carry docblocks
- [x] New tests added and passing
- [x] The two new runtime classes follow the package's existing file header and namespace conventions
